### PR TITLE
Fix new vaa format

### DIFF
--- a/metno-vaa-kml
+++ b/metno-vaa-kml
@@ -131,6 +131,7 @@ sub readfile {
 sub get_parser {
     use Regexp::Grammars;
     return qr{
+        <timeout: 15>
         <nocontext:>
 
         ^
@@ -300,7 +301,7 @@ sub get_parser {
         <rule: OBSVACLD>
             OBS VA CLD:
             (?:
-              <[ForecastArea]>+ % <.ws>
+              <[ForecastArea]>+ % <.ws> <message=va_mov>? #Get a forecast area followed by possible MOV statement we ignore
             | <message=fcstmessage>
             | <message=notobserved>
             | <message=notdetected>
@@ -318,6 +319,7 @@ sub get_parser {
         <rule: notprovided>  NOT PROVIDED
         <rule: notobserved>  VA NOT OBSERVED
         <rule: notdetected>  NO VA DETECTED
+        <rule: va_mov>       MOV <anytext>?
 
         <rule: notidentifiable>
             (?: VA | ASH ) NOT IDENTIFIABLE <anytext>

--- a/metno-vaa-kml
+++ b/metno-vaa-kml
@@ -29,7 +29,7 @@ use Data::Dumper;
 #my $url = "file:///disk1/ash/e.20130703145900.GRIMSVOTN.201301.201307031445.html";
 #my $url = "file:///disk1/ash/e.20130903095900.VULCANO.2013001.201309031000.html";
 #my $url = "file://" . $ARGV[0];
-#my $doc = get $url 
+#my $doc = get $url
 #    or die "Could not fetch $url";
 
 my $infile = shift;
@@ -59,16 +59,16 @@ for (my $i=0; $i<$#lines; $i++) {
     $line =~ s/\s+$//;
 
     if ($line !~ /:/) {
-	if (not $seencolon) {
-	    push @content, $line;
-	} else {
-#	    print "appending: $line (\$i = $i)\n";
-	    $content[-1] .= " " . $line;
-	}
+        if (not $seencolon) {
+            push @content, $line;
+        } else {
+            #print "appending: $line (\$i = $i)\n";
+            $content[-1] .= " " . $line;
+        }
     } else {
-#	print $line, "\n";
-	$seencolon = 1;
-	push @content, $line;
+        #print $line, "\n";
+        $seencolon = 1;
+        push @content, $line;
     }
 }
 
@@ -77,19 +77,19 @@ for (my $i=0; $i<$#lines; $i++) {
 for (my $i=0; $i<$#content; $i++) {
     my $line = $content[$i];
     if ($line =~ $parser) {
-#	delete $/{''};
-	my ($k, $v) = %/; # only one key left
+        #delete $/{''};
+        my ($k, $v) = %/; # only one key left
 
-	if ($k eq 'FCSTVACLD') {
-	    $ash{lc $k}{ $v->{offset} } = $v;
-	} else {
-	    $ash{lc $k} = $v;
-	}
+        if ($k eq 'FCSTVACLD') {
+            $ash{lc $k}{ $v->{offset} } = $v;
+        } else {
+            $ash{lc $k} = $v;
+        }
     } else {
-#	warn "   --- could not parse following line: ---\n";
-#	print $line, "\n";
-	$error++;
-	push @fail, $line;
+        #warn "   --- could not parse following line: ---\n";
+        #print $line, "\n";
+        $error++;
+        push @fail, "$line\n";
     }
 }
 
@@ -154,7 +154,7 @@ sub get_parser {
         |   <REMARKS>
         |   <NEXTADVISORY>
         )
-        \.? 
+        \.?
         $
 
         <token: anytext> .*
@@ -171,18 +171,18 @@ sub get_parser {
 
         <token: time>
            <hour> <min> <tz>?
-        
+
         <token: tz>
            [+-]\d\d\d\d | Z
-        
+
         <token: Daytime>
            <day> / <time>
            <MATCH=(?{ { day => $MATCH{day}, %{$MATCH{time}} } })>
-        
+
         <token: flightlevel>
            (?:
                <MATCH=singleflightlevel>
-               | 
+               |
                <MATCH=doubleflightlevel>
            )
 
@@ -192,22 +192,22 @@ sub get_parser {
         <token: singleflightlevel>
            SFC / FL <to=level>
            (?{ $MATCH{from} = 0 })
-        
-        <token: level> 
+
+        <token: level>
            \d\d\d
 
         <token: lat>
            <direction=([NS])> <degree=(\d\d\d?)> <minute=([0-5]\d)>
            <MATCH=(?{ ($MATCH{degree} + $MATCH{minute} / 60) * ($MATCH{direction} eq "S" ? -1 : 1)})>
-        
+
         <token: lon>
            <direction=([EW])> <degree=(\d\d\d)> <minute=([0-5]\d)>
            <MATCH=(?{ ($MATCH{degree} + $MATCH{minute} / 60) * ($MATCH{direction} eq "W" ? -1 : 1)})>
-        
+
         <rule: latlonpair>
            <lat> <lon>
 #           <MATCH=(?{ [$MATCH{lat}, $MATCH{lon}] })>
-        
+
         <rule: movement>
             MOV <direction> <speed=(\d+)> <unit=(KT)>
 
@@ -217,10 +217,10 @@ sub get_parser {
             |   NNE | ENE | ESE | SSE
             |   NNW | WNW | WSW | SSW
             )
-            
+
         <token: separator>
             <.ws> - <.ws>
-        
+
         <rule: ForecastArea>
             <flightlevel>
             <[pos=latlonpair]>+ % <.separator>
@@ -238,7 +238,7 @@ sub get_parser {
             VAAC: <MATCH=anytext>
 
         <rule: VOLCANO>
-            VOLCANO: 
+            VOLCANO:
             (?:
                 <name=anytext> \s+ <id=iavcei>
             |
@@ -255,8 +255,8 @@ sub get_parser {
             AREA: <name=anytext>
 
         <rule: SUMMITELEV>
-            SUMMIT ELEV: 
-            (?: 
+            SUMMIT ELEV:
+            (?:
                 <ele=(\d+)> (?: <units=meters> | <units=feet> )
                 (?: \( \d+ (?: <meters> | <feet> ) \) )?
             |
@@ -284,7 +284,7 @@ sub get_parser {
             (?: REMARKS | RMK): <.ws> <MATCH=anytext>
 
         <rule: NEXTADVISORY>
-            NXT ADVISORY: 
+            NXT ADVISORY:
             (?: <anydateformat>
             |   <text=(NO LATER THAN)> <anydateformat>
             |   <text=(WILL BE ISSUED BY)> <anydateformat>
@@ -307,7 +307,7 @@ sub get_parser {
             )?
 
         <rule: ESTVACLD>
-            EST VA CLD: 
+            EST VA CLD:
             (?:
               <[ForecastArea]>+ % <.ws>
             | <message=fcstmessage>
@@ -319,7 +319,7 @@ sub get_parser {
         <rule: notobserved>  VA NOT OBSERVED
         <rule: notdetected>  NO VA DETECTED
 
-        <rule: notidentifiable> 
+        <rule: notidentifiable>
             (?: VA | ASH ) NOT IDENTIFIABLE <anytext>
 
         <rule: terminated>    <anytext> TERMINATED
@@ -337,8 +337,8 @@ sub get_parser {
         <rule: FCSTVACLD>
             FCST VA CLD \+ <offset=(\d+)>\s?HR?:
             (?:
-                <Daytime> 
-                (?: 
+                <Daytime>
+                (?:
                     (?:
                       <[ForecastArea]>+ % <.ws>
                     | <message=fcstmessage>

--- a/metno-vaa-kml
+++ b/metno-vaa-kml
@@ -335,7 +335,7 @@ sub get_parser {
             )
 
         <rule: FCSTVACLD>
-            FCST VA CLD \+ <offset=(\d+)>HR?: 
+            FCST VA CLD \+ <offset=(\d+)>\s?HR?:
             (?:
                 <Daytime> 
                 (?: 


### PR DESCRIPTION
This fixes handling of new space by changing the grammar
Old: "FCST VA CLD +6HR:"
New: "FCST VA CLD +6 HR:"

Should handle both old and new format. 